### PR TITLE
Curated list dash

### DIFF
--- a/app/javascript/packs/CuratedList.jsx
+++ b/app/javascript/packs/CuratedList.jsx
@@ -1,0 +1,25 @@
+import { h, render } from 'preact';
+import { getUserDataAndCsrfToken } from '../chat/util';
+import { CuratedList } from '../readingList/CuratedList';
+
+function loadElement() {
+  getUserDataAndCsrfToken().then(({ currentUser }) => {
+    const root = document.getElementById('reading-list');
+    if (root) {
+      render(
+        <CuratedList
+          // availableTags={currentUser.followed_tag_names}
+          // statusView={root.dataset.view}
+        />,
+        root,
+        root.firstElementChild,
+      );
+    }
+  });
+}
+
+window.InstantClick.on('change', () => {
+  loadElement();
+});
+
+loadElement();

--- a/app/javascript/packs/NewListForm.jsx
+++ b/app/javascript/packs/NewListForm.jsx
@@ -1,0 +1,25 @@
+import { h, render } from 'preact';
+import { getUserDataAndCsrfToken } from '../chat/util';
+import { NewListForm } from '../readingList/NewListForm';
+
+function loadElement() {
+  getUserDataAndCsrfToken().then(({ currentUser }) => {
+    const root = document.getElementById('reading-list');
+    if (root) {
+      render(
+        <NewListForm
+          // availableTags={currentUser.followed_tag_names}
+          // statusView={root.dataset.view}
+        />,
+        root,
+        root.firstElementChild,
+      );
+    }
+  });
+}
+
+window.InstantClick.on('change', () => {
+  loadElement();
+});
+
+loadElement();

--- a/app/javascript/readingList/CuratedList.jsx
+++ b/app/javascript/readingList/CuratedList.jsx
@@ -16,7 +16,6 @@ import { ItemListItemArchiveButton } from '../src/components/ItemList/ItemListIt
 import { ItemListLoadMoreButton } from '../src/components/ItemList/ItemListLoadMoreButton';
 import { ItemListTags } from '../src/components/ItemList/ItemListTags';
 
-
 const STATUS_VIEW_VALID = 'valid';
 const STATUS_VIEW_ARCHIVED = 'archived';
 const READING_LIST_ARCHIVE_PATH = '/readinglist/archive';

--- a/app/javascript/readingList/CuratedList.jsx
+++ b/app/javascript/readingList/CuratedList.jsx
@@ -18,6 +18,7 @@ import { ItemListTags } from '../src/components/ItemList/ItemListTags';
 
 const STATUS_VIEW_VALID = 'valid';
 const STATUS_VIEW_ARCHIVED = 'archived';
+// change these to curated list path once route is in place?
 const READING_LIST_ARCHIVE_PATH = '/readinglist/archive';
 const READING_LIST_PATH = '/readinglist';
 

--- a/app/javascript/readingList/CuratedList.jsx
+++ b/app/javascript/readingList/CuratedList.jsx
@@ -1,0 +1,3 @@
+import { h, Component } from 'preact';
+import { PropTypes } from 'preact-compat';
+import debounce from 'lodash.debounce';

--- a/app/javascript/readingList/CuratedList.jsx
+++ b/app/javascript/readingList/CuratedList.jsx
@@ -25,6 +25,7 @@ const READING_LIST_PATH = '/readinglist';
 export class CuratedList extends Component {
   constructor(props) {
     super(props);
+    this.state = {name: '', description: '', articles: []}
 
     // const { availableTags, statusView } = this.props;
     // this.state = defaultState({ availableTags, archiving: false, statusView });
@@ -54,15 +55,15 @@ export class CuratedList extends Component {
     // });
   }
   render() {
-    const {
-      items,
-      itemsLoaded,
-      totalCount,
-      availableTags,
-      selectedTags,
-      showLoadMoreButton,
-      archiving,
-    } = this.state;
+    // const {
+    //   items,
+    //   itemsLoaded,
+    //   totalCount,
+    //   availableTags,
+    //   selectedTags,
+    //   showLoadMoreButton,
+    //   archiving,
+    // } = this.state;
 
     const isStatusViewValid = this.statusViewValid();
 

--- a/app/javascript/readingList/CuratedList.jsx
+++ b/app/javascript/readingList/CuratedList.jsx
@@ -68,6 +68,7 @@ export class CuratedList extends Component {
     const isStatusViewValid = this.statusViewValid();
 
     const archiveButtonLabel = isStatusViewValid ? 'archive' : 'unarchive';
+    // itemsToRender will map over each article in a specific curated list, assign the resulting ItemListItem to an array
     const itemsToRender = items.map(item => {
       return (
         <ItemListItem item={item}>
@@ -87,6 +88,7 @@ export class CuratedList extends Component {
       ''
     );
     return (
+      // when rendered, find articles within state or wherever they are stored, render each one of those as a ItemListItem
       <div className="home item-list">
         <div className="side-bar">
           <div className="widget filters">

--- a/app/javascript/readingList/CuratedList.jsx
+++ b/app/javascript/readingList/CuratedList.jsx
@@ -1,3 +1,163 @@
 import { h, Component } from 'preact';
 import { PropTypes } from 'preact-compat';
 import debounce from 'lodash.debounce';
+
+import {
+  defaultState,
+  loadNextPage,
+  onSearchBoxType,
+  performInitialSearch,
+  search,
+  toggleTag,
+  clearSelectedTags,
+} from '../searchableItemList/searchableItemList';
+import { ItemListItem } from '../src/components/ItemList/ItemListItem';
+import { ItemListItemArchiveButton } from '../src/components/ItemList/ItemListItemArchiveButton';
+import { ItemListLoadMoreButton } from '../src/components/ItemList/ItemListLoadMoreButton';
+import { ItemListTags } from '../src/components/ItemList/ItemListTags';
+
+
+const STATUS_VIEW_VALID = 'valid';
+const STATUS_VIEW_ARCHIVED = 'archived';
+const READING_LIST_ARCHIVE_PATH = '/readinglist/archive';
+const READING_LIST_PATH = '/readinglist';
+
+export class CuratedList extends Component {
+  constructor(props) {
+    super(props);
+
+    // const { availableTags, statusView } = this.props;
+    // this.state = defaultState({ availableTags, archiving: false, statusView });
+
+    // bind and initialize all shared functions
+    this.onSearchBoxType = debounce(onSearchBoxType.bind(this), 300, {
+      leading: true,
+    });
+    // bind these functions to the context of this component
+    this.loadNextPage = loadNextPage.bind(this);
+    this.performInitialSearch = performInitialSearch.bind(this);
+    this.search = search.bind(this);
+    this.toggleTag = toggleTag.bind(this);
+    this.clearSelectedTags = clearSelectedTags.bind(this);
+  }
+
+  componentDidMount() {
+    // const { hitsPerPage, statusView } = this.state;
+
+    // this.performInitialSearch({
+    //   containerId: 'reading-list',
+    //   indexName: 'SecuredReactions',
+    //   searchOptions: {
+    //     hitsPerPage,
+    //     filters: `status:${statusView}`,
+    //   },
+    // });
+  }
+  render() {
+    const {
+      items,
+      itemsLoaded,
+      totalCount,
+      availableTags,
+      selectedTags,
+      showLoadMoreButton,
+      archiving,
+    } = this.state;
+
+    const isStatusViewValid = this.statusViewValid();
+
+    const archiveButtonLabel = isStatusViewValid ? 'archive' : 'unarchive';
+    const itemsToRender = items.map(item => {
+      return (
+        <ItemListItem item={item}>
+          <ItemListItemArchiveButton
+            text={archiveButtonLabel}
+            onClick={e => this.toggleArchiveStatus(e, item)}
+          />
+        </ItemListItem>
+      );
+    });
+
+    const snackBar = archiving ? (
+      <div className="snackbar">
+        {isStatusViewValid ? 'Archiving...' : 'Unarchiving...'}
+      </div>
+    ) : (
+      ''
+    );
+    return (
+      <div className="home item-list">
+        <div className="side-bar">
+          <div className="widget filters">
+            <input
+              onKeyUp={this.onSearchBoxType}
+              placeHolder="search your list"
+            />
+            <div className="filters-header">
+              <h4 className="filters-header-text">my tags</h4>
+              {Boolean(selectedTags.length) && (
+                <a
+                  className="filters-header-action"
+                  href={
+                    isStatusViewValid
+                      ? READING_LIST_PATH
+                      : READING_LIST_ARCHIVE_PATH
+                  }
+                  onClick={this.clearSelectedTags}
+                  data-no-instant
+                >
+                  clear all
+                </a>
+              )}
+            </div>
+            <ItemListTags
+              availableTags={availableTags}
+              selectedTags={selectedTags}
+              onClick={this.toggleTag}
+            />
+
+            <div className="status-view-toggle">
+              <a
+                href={READING_LIST_ARCHIVE_PATH}
+                onClick={e => this.toggleStatusView(e)}
+                data-no-instant
+              >
+                {isStatusViewValid ? 'View Archive' : 'View Reading List'}
+              </a>
+            </div>
+          </div>
+          <div className='curated-lists'>
+            <h2>Curated Lists</h2>
+            {/* on click, display addCuratedList form */}
+            <button>+</button>
+            <ul>
+              {/* // make these clickable and links to a curatedList component view */}
+              <p></p><li>Best of 2019</li>
+              <p></p><li>Cool Stuff</li>
+            </ul>
+            <NewListForm />
+          </div>
+        </div>
+
+        <div className="items-container">
+          <div className={`results ${itemsLoaded ? 'results--loaded' : ''}`}>
+            <div className="results-header">
+              {isStatusViewValid ? 'Reading List' : 'Archive'}
+              {` (${totalCount > 0 ? totalCount : 'empty'})`}
+            </div>
+            <div>
+              {items.length > 0 ? itemsToRender : this.renderEmptyItems()}
+            </div>
+          </div>
+
+          <ItemListLoadMoreButton
+            show={showLoadMoreButton}
+            onClick={this.loadNextPage}
+          />
+        </div>
+
+        {snackBar}
+      </div>
+    );
+  }
+}

--- a/app/javascript/readingList/NewListForm.jsx
+++ b/app/javascript/readingList/NewListForm.jsx
@@ -1,0 +1,44 @@
+import { h, Component } from 'preact';
+import { PropTypes } from 'preact-compat';
+import debounce from 'lodash.debounce';
+
+export class NewListForm extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      name: '',
+      description: ''
+    }
+  }
+  // handleChange = e => {
+  //   this.setState({ [e.target.name]: e.target.value})
+  // }
+  handleClick = e => {
+    e.preventDefault();
+    console.log(this.state)
+  }
+  render() {
+    const { title, description } = this.state
+    return (
+      <form className='new-list-form'>
+        <input
+          className='new-list-form__title'
+          type="text"
+          placeholder="Title"
+          name="title"
+          value={title}
+          onChange={this.handleChange}
+        />
+        <input
+          className='new-list-form__description'
+          type="text"
+          placeholder="Description"
+          name="description"
+          value={description}
+          onChange={this.handleChange}
+        />
+        <button className='new-list-form__button'>Create Curated List</button>
+        {/* onClick={() => this.handleClick()} */}
+    </form>)
+  }
+}

--- a/app/javascript/readingList/NewListForm.jsx
+++ b/app/javascript/readingList/NewListForm.jsx
@@ -10,9 +10,9 @@ export class NewListForm extends Component {
       description: ''
     }
   }
-  // handleChange = e => {
-  //   this.setState({ [e.target.name]: e.target.value})
-  // }
+  handleChange = e => {
+    this.setState({ [e.target.name]: e.target.value})
+  }
   handleClick = e => {
     e.preventDefault();
     console.log(this.state)

--- a/app/javascript/readingList/addNewListForm.jsx
+++ b/app/javascript/readingList/addNewListForm.jsx
@@ -1,0 +1,3 @@
+import { h, Component } from 'preact';
+import { PropTypes } from 'preact-compat';
+import debounce from 'lodash.debounce';

--- a/app/javascript/readingList/addNewListForm.jsx
+++ b/app/javascript/readingList/addNewListForm.jsx
@@ -1,3 +1,0 @@
-import { h, Component } from 'preact';
-import { PropTypes } from 'preact-compat';
-import debounce from 'lodash.debounce';

--- a/app/javascript/readingList/readingList.jsx
+++ b/app/javascript/readingList/readingList.jsx
@@ -42,6 +42,7 @@ export class ReadingList extends Component {
     this.onSearchBoxType = debounce(onSearchBoxType.bind(this), 300, {
       leading: true,
     });
+    // bind these functions to the context of this component
     this.loadNextPage = loadNextPage.bind(this);
     this.performInitialSearch = performInitialSearch.bind(this);
     this.search = search.bind(this);
@@ -232,6 +233,16 @@ export class ReadingList extends Component {
                 {isStatusViewValid ? 'View Archive' : 'View Reading List'}
               </a>
             </div>
+          </div>
+          <div className='curated-lists'>
+            <h2>Curated Lists</h2>
+            {/* on click, display addCuratedList form */}
+            <button>+</button>
+            <ul>
+              {/* // make these clickable and links to a curatedList component view */}
+              <p></p><li>Best of 2019</li>
+              <p></p><li>Cool Stuff</li>
+            </ul>
           </div>
         </div>
 

--- a/app/javascript/readingList/readingList.jsx
+++ b/app/javascript/readingList/readingList.jsx
@@ -1,6 +1,7 @@
 import { h, Component } from 'preact';
 import { PropTypes } from 'preact-compat';
 import debounce from 'lodash.debounce';
+import { NewListForm } from './NewListForm'
 
 import {
   defaultState,
@@ -243,6 +244,7 @@ export class ReadingList extends Component {
               <p></p><li>Best of 2019</li>
               <p></p><li>Cool Stuff</li>
             </ul>
+            <NewListForm />
           </div>
         </div>
 

--- a/app/javascript/readingList/readingList.jsx
+++ b/app/javascript/readingList/readingList.jsx
@@ -240,7 +240,7 @@ export class ReadingList extends Component {
             {/* on click, display addCuratedList form */}
             <button>+</button>
             <ul>
-              {/* // make these clickable and links to a curatedList component view */}
+              {/* render each curated list as a button linking to the curatedList component view, will implement once curatedList data is linked and passed */}
               <p></p><li>Best of 2019</li>
               <p></p><li>Cool Stuff</li>
             </ul>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Problem 
Need a couple new components to handle the functionality on our track. Mostly, need the actual CuratedList component and a form to add new ones. Planning to reuse ItemListItem component to render each article card within a curated list, just like the current readingList component. 

## Description
This PR adds two static components (not hooked up to anything yet or being rendered): CuratedList and NewListForm. The NewListForm will appear when a user selects the `add new curated list` button from the reading list dashboard. Once this form is submitted, a new CuratedList will be generated. The CuratedList component is a cannibalized ReadingList component. Since we want the UI to be basically the same, but need it to be its own component, I re-used most of the readingList. This is very roughly laid out right now and is just the beginning stages. There is some pseudocode describing future steps once things are linked together. 
## Related Tickets & Documents
This PR is related to many issues, but does not yet resolve any of them. 

