### PR TITLE
Fix curated list creation

### DIFF
--- a/app/controllers/curated_lists_controller.rb
+++ b/app/controllers/curated_lists_controller.rb
@@ -1,15 +1,17 @@
 class CuratedListsController < ApplicationController
   def show
-    found_list = CuratedList.where('user_id = ? AND slug = ?', id_for_username(params[:username]), params[:slug]).first.to_json
+    found_list = CuratedList.where("user_id = ? AND slug = ?", id_for_username(params[:username]), params[:slug]).first.to_json
     @curated_list = CuratedListSerializer.new([found_list]).to_json
   end
 
   def create
     user = User.find(session_current_user_id)
     new_list = user.curated_lists.new(strong_params)
-    if new_list.save
-      flash[:success] = 'Hooray!'
-    end
+    render json: if new_list.save
+                   new_list.to_json
+                 else
+                   new_list.errors.to_json
+                 end
   end
 
   private
@@ -19,6 +21,6 @@ class CuratedListsController < ApplicationController
   end
 
   def strong_params
-    params.permit(:name, :description)
+    params.permit(:name, :description, :slug)
   end
 end

--- a/app/javascript/readingList/NewListForm.jsx
+++ b/app/javascript/readingList/NewListForm.jsx
@@ -13,7 +13,7 @@ export class NewListForm extends Component {
   handleChange = e => {
     this.setState({ [e.target.name]: e.target.value})
   }
-  handleClick = e => {
+  handleSubmit = e => {
     e.preventDefault();
     window.fetch(`/${this.props.username}/curated_lists`, {
       method: 'POST',
@@ -22,20 +22,26 @@ export class NewListForm extends Component {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ name: this.state.name,
-                             description: this.state.description }),
+                             description: this.state.description,
+                             slug: this.sluggify(this.state.name)}),
       credentials: 'same-origin',
     });
   }
+
+  sluggify = name => {
+    return name.replace(/ +/g, '-').toLowerCase();
+  };
+
   render() {
-    const { title, description } = this.state
+    const { name, description } = this.state
     return (
-      <form className='new-list-form' onSubmit={this.handleClick}>
+      <form className='new-list-form' onSubmit={this.handleSubmit}>
         <input
-          className='new-list-form__title'
+          className='new-list-form__name'
           type="text"
-          placeholder="Title"
-          name="title"
-          value={title}
+          placeholder="Name"
+          name="name"
+          value={name}
           onChange={(e) => this.handleChange(e)}
         />
         <input
@@ -46,10 +52,7 @@ export class NewListForm extends Component {
           value={description}
           onChange={(e) => this.handleChange(e)}
         />
-        <button className='new-list-form__button'
-                // type='submit'
-                // onClick={() => this.handleClick()}
-                >
+        <button className='new-list-form__button'>
           Create Curated List
         </button>
 


### PR DESCRIPTION
## Issues resolved
Resolves #39 (mostly, see below)

## Problem
Clicking "create curated list" on form on reading list dash was not successfully creating a new curated list.

## Solution
Updated controller's create action to expect a "slug" parameter, and updated NewList form to create one dynamically from the name and include it in the body of the POST request.

## Further known issues
- List of user's curated lists doesn't refresh, have to manually refresh page
- (related) Fields remain filled after clicking submit
- Some intermittent weird behavior still around changing fields, seeing that post error from honeybadger